### PR TITLE
[ADD] PostView 스크랩 했을 때 스크랩 보러가기 버튼 구현

### DIFF
--- a/VelogOnMobile/Feature/TabBar/TabBarController.swift
+++ b/VelogOnMobile/Feature/TabBar/TabBarController.swift
@@ -57,6 +57,7 @@ final class TabBarController: UITabBarController {
     
     private func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNotification(_:)), name: Notification.Name("ScrapButtonTappedNotification"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(scrapBookButtonTapped), name: Notification.Name("MoveToScrapStorage"), object: nil)
     }
     
     @objc
@@ -115,6 +116,7 @@ extension TabBarController: UITabBarControllerDelegate {
 }
 
 extension TabBarController: ScrapPopUpDelegate {
+    @objc
     func scrapBookButtonTapped() {
         selectedIndex = 2
     }

--- a/VelogOnMobile/Feature/WebView/ViewController/WebViewController.swift
+++ b/VelogOnMobile/Feature/WebView/ViewController/WebViewController.swift
@@ -133,6 +133,13 @@ final class WebViewController: RxBaseViewController<WebViewModel> {
                 }
             })
             .disposed(by: disposeBag)
+        
+        scrapPopUpView.moveToStorageButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+                NotificationCenter.default.post(name: Notification.Name("MoveToScrapStorage"), object: nil)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindOutput(_ viewModel: WebViewModel) {


### PR DESCRIPTION
## 📌 Summary

PostView 스크랩 했을 때 스크랩 보러가기 버튼 구현했습니다.
TabBar의 NotificationCenter에 추가하는 방식으로 구현했습니다.

## ✍️ Description

- 이슈 티켓 : #139 

## 🔥 Test

![화면_기록_2023-06-12_오후_6_19_31_AdobeExpress](https://github.com/hongjunehuke/VelogOniOS/assets/83629193/c3bf5db4-51be-45a5-a5c5-5cc95c454e0c)

